### PR TITLE
Fix transitionend event bug

### DIFF
--- a/src/TransitionChild.js
+++ b/src/TransitionChild.js
@@ -181,6 +181,13 @@ var TransitionChild = React.createClass({
     this._phase = phase;
 
     var nextStyle = this._computeNewStyle(phase);
+
+    // matching styles results in no "transitionend" event
+    if (JSON.stringify(this.state.style) === JSON.stringify(nextStyle)) {
+      callback();
+      return;
+    }
+
     var transitionValues = TransitionParser.getTransitionValues(nextStyle);
 
     var maxTimeProperty = TransitionInfo.getMaximumTimeProperty(


### PR DESCRIPTION
In some cases if the current and next styles are the same no transitionend event will be fired and
the callback not called, this adds a simple comparison of styles to make sure this doesn't happen.

In my case this happens when then transitions are triggered in quick succession for mouseenter, mouseleave.