### PR TITLE
Fix PropTypes Warning for `component`

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -24,7 +24,6 @@ var Transition = React.createClass({
     component: React.PropTypes.oneOfType([
       React.PropTypes.node,
       React.PropTypes.func,
-      React.PropTypes.element,
     ]),
     onPhaseEnd: React.PropTypes.func,
     onPhaseStart: React.PropTypes.func,

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -22,7 +22,7 @@ var Transition = React.createClass({
       leave: React.PropTypes.object,
     }),
     component: React.PropTypes.oneOfType([
-      React.PropTypes.node,
+      React.PropTypes.string,
       React.PropTypes.func,
     ]),
     onPhaseEnd: React.PropTypes.func,

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -21,7 +21,11 @@ var Transition = React.createClass({
       enter: React.PropTypes.object,
       leave: React.PropTypes.object,
     }),
-    component: React.PropTypes.string,
+    component: React.PropTypes.oneOfType([
+      React.PropTypes.node,
+      React.PropTypes.func,
+      React.PropTypes.element,
+    ]),
     onPhaseEnd: React.PropTypes.func,
     onPhaseStart: React.PropTypes.func,
   },


### PR DESCRIPTION
TransitionHooks can render stateless components and react elements as well as traditional elements (like `div`) already. This fix suppresses the proptype warnings. 

```
component: React.PropTypes.oneOfType([
    React.PropTypes.node, // anything that can be rendered, including a string
    React.PropTypes.func, // react component
]),
```