### PR TITLE
Fix handling of cubic-bezier() timing function

### DIFF
--- a/src/TransitionParser.js
+++ b/src/TransitionParser.js
@@ -68,7 +68,7 @@ var _parseShorthand = function (propertyStr) {
   var delayArray = [];
   var re = /^([0-9]*\.?[0-9]+)(m?s)$/;
   var transitions =
-    propertyStr.toLowerCase().replace(/cubic\-bezier\(.*\)/, '').trim()
+    propertyStr.toLowerCase().replace(/cubic\-bezier\((.*?)\)/g, '').trim()
     .split(/\s*,\s*/);
 
   for (var i = 0; i < transitions.length; i++) {

--- a/src/__tests__/TransitionParser-test.js
+++ b/src/__tests__/TransitionParser-test.js
@@ -24,7 +24,8 @@ describe('TransitionParser', function () {
       background: '#FFF',
       height: '50px',
       width: '50px',
-      transition: 'background 1s 1s, height 2s cubic-bezier(0,0,0,0) 2s, ' +
+      transition: 'background 1s 1s, height 2s ' +
+        'cubic-bezier(0.25, 0, .45, 2) 2s, ' +
         'width 3s linear',
     };
 

--- a/src/__tests__/TransitionParser-test.js
+++ b/src/__tests__/TransitionParser-test.js
@@ -25,8 +25,8 @@ describe('TransitionParser', function () {
       height: '50px',
       width: '50px',
       transition: 'background 1s 1s, height 2s ' +
-        'cubic-bezier(0.25, 0, .45, 2) 2s, ' +
-        'width 3s linear',
+        'color 2s cubic-bezier(0.25, 0, .45, 2), ' +
+        'width 3s cubic-bezier(0.15, 1, 0.75, 4)',
     };
 
     var transitions = TransitionParser.getTransitionValues(style);


### PR DESCRIPTION
The regular expression that deals with the `cubic-bezier()` timing function should deal with every possibility in it’s values and the regular expression should search globally to find every incident in a string. There could be multiple transition definitions inside one string like:
`opacity 300ms cubic-bezier(0.25, 1, 0.25, 1), transform 375ms ease-out, background 250ms cubic-bezier(0.25, 1, 0.25, 1)`.